### PR TITLE
04 ls -aの実装

### DIFF
--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -5,8 +5,8 @@ require 'optparse'
 MAX_COLUMN = 3
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
-def current_directory_content_names
-  Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
+def current_directory_content_names(option_hash)
+  option_hash[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
 def sort_vertically(content_names)
@@ -57,7 +57,7 @@ option_hash = {option_lower_a: false}
 option_lower_a = command_line_option_parser
 option_hash[:option_lower_a] = option_lower_a
 
-content_names = current_directory_content_names
+content_names = current_directory_content_names(option_hash)
 max_content_name_length = content_names.map(&:length).max
 sorted_content_names = sort_vertically(content_names)
 

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -54,9 +54,9 @@ def parse_command_line_option
   { option_lower_a: }
 end
 
-option_hash = parse_command_line_option
+options = parse_command_line_option
 
-content_names = current_directory_content_names(option_hash)
+content_names = current_directory_content_names(options)
 max_content_name_length = content_names.map(&:length).max
 sorted_content_names = sort_vertically(content_names)
 

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+require 'optparse'
 
 MAX_COLUMN = 3
 
@@ -42,6 +43,19 @@ def make_divided_content_names(content_names_without_max_line_column, divid_coun
   end
   divided_content_names
 end
+
+def command_line_option_parser
+  option_lower_a = false
+
+  opt = OptionParser.new
+  opt.on('-a', '--add', 'add an item') { option_lower_a = true }
+  opt.parse(ARGV)
+  option_lower_a
+end
+
+option_hash = {option_lower_a: false}
+option_lower_a = command_line_option_parser
+option_hash[:option_lower_a] = option_lower_a
 
 content_names = current_directory_content_names
 max_content_name_length = content_names.map(&:length).max

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require 'optparse'
 
 MAX_COLUMN = 3
@@ -53,7 +54,7 @@ def command_line_option_parser
   option_lower_a
 end
 
-option_hash = {option_lower_a: false}
+option_hash = { option_lower_a: false }
 option_lower_a = command_line_option_parser
 option_hash[:option_lower_a] = option_lower_a
 

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -45,7 +45,7 @@ def make_divided_content_names(content_names_without_max_line_column, divid_coun
   divided_content_names
 end
 
-def command_line_option_parser
+def parse_command_line_option
   option_lower_a = false
 
   opt = OptionParser.new
@@ -55,7 +55,7 @@ def command_line_option_parser
 end
 
 option_hash = { option_lower_a: false }
-option_lower_a = command_line_option_parser
+option_lower_a = parse_command_line_option
 option_hash[:option_lower_a] = option_lower_a
 
 content_names = current_directory_content_names(option_hash)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -51,12 +51,10 @@ def parse_command_line_option
   opt = OptionParser.new
   opt.on('-a', '--add', 'add an item') { option_lower_a = true }
   opt.parse(ARGV)
-  option_lower_a
+  { option_lower_a: }
 end
 
-option_hash = { option_lower_a: false }
-option_lower_a = parse_command_line_option
-option_hash[:option_lower_a] = option_lower_a
+option_hash = parse_command_line_option
 
 content_names = current_directory_content_names(option_hash)
 max_content_name_length = content_names.map(&:length).max


### PR DESCRIPTION
# 概要

#### ls -aとは
ファイル名の先頭にピリオドがあるファイルも表示するオプション

#### 変更内容
- コマンドラインオプションを受け取れるようにする
- オプション`-a`が指定された場合、ファイルの先頭に`.` があるファイルも表示対象とする。
  - 例：`-a`ありの場合、`.ssh`ファイルも表示。 `-a`無しの場合、`.ssh`ファイルは非表示。

# Preview
<img width="485" alt="スクリーンショット 2023-09-22 11 32 36" src="https://github.com/daisuke0926dev/ruby-practices/assets/90462400/3dc3d34e-de39-4689-af52-c980c6614ae4">

# rubocop
<img width="357" alt="スクリーンショット 2023-09-22 11 33 27" src="https://github.com/daisuke0926dev/ruby-practices/assets/90462400/dde960dc-b63c-48c8-9c9d-4259b8d8c059">

# Other
前回のpr:https://github.com/daisuke0926dev/ruby-practices/pull/4