### PR TITLE
04ls -rの実装

### DIFF
--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -10,18 +10,17 @@ def current_directory_content_names(options)
   options[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
-def sort_vertically(content_names, options)
+def sort_vertically(content_names)
   sorted_content_names = []
   max_number_of_lines = (content_names.size / MAX_COLUMN.to_f).ceil
   limit_per_line = (content_names.size / max_number_of_lines.to_f).ceil
   amount_of_max_line_column = limit_per_line - ((max_number_of_lines * limit_per_line) % content_names.size)
 
-  simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
   amount_of_max_line_column.times do |line|
-    sorted_content_names.push(simple_sorted_content_names[(line * max_number_of_lines), max_number_of_lines])
+    sorted_content_names.push(content_names[(line * max_number_of_lines), max_number_of_lines])
   end
 
-  content_names_without_max_line_column = simple_sorted_content_names[amount_of_max_line_column * max_number_of_lines..]
+  content_names_without_max_line_column = content_names[amount_of_max_line_column * max_number_of_lines..]
 
   # 転置後、縦に連番させるために、配列を区切ります
   divided_content_names_without_max_line_column =
@@ -62,7 +61,9 @@ options = parse_command_line_option
 
 content_names = current_directory_content_names(options)
 max_content_name_length = content_names.map(&:length).max
-sorted_content_names = sort_vertically(content_names, options)
+
+simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
+sorted_content_names = sort_vertically(simple_sorted_content_names)
 
 sorted_content_names.each do |sorted_content_name|
   sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -8,7 +8,7 @@ MAX_COLUMN = 3
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
 def current_directory_content_names(options)
-  options[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
+  options[:option_show_hidden_files] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
 def sort_vertically(content_names)
@@ -46,16 +46,16 @@ def make_divided_content_names(content_names_without_max_line_column, divid_coun
 end
 
 def parse_command_line_option
-  option_lower_a = false
+  option_show_hidden_files = false
   option_reverse = false
-  option_lower_l = false
+  option_detailed_listing = false
 
   opt = OptionParser.new
-  opt.on('-a', '--add', 'add an item') { option_lower_a = true }
+  opt.on('-a', '--all', 'show all items') { option_show_hidden_files = true }
   opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
-  opt.on('-l', '', 'show items detail') { option_lower_l = true }
+  opt.on('-l', '', 'detailed list of items') { option_detailed_listing = true }
   opt.parse(ARGV)
-  { option_lower_a:, option_reverse:, option_lower_l: }
+  { option_show_hidden_files:, option_reverse:, option_detailed_listing: }
 end
 
 def sort_with_details(content_names)
@@ -127,7 +127,7 @@ end
 options = parse_command_line_option
 content_names = current_directory_content_names(options)
 simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
-if options[:option_lower_l]
+if options[:option_detailed_listing]
   sorted_content_names_with_details, block_size = sort_with_details(simple_sorted_content_names)
   display_sorted_contents(sorted_content_names_with_details, block_size)
 else

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -6,8 +6,8 @@ require 'optparse'
 MAX_COLUMN = 3
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
-def current_directory_content_names(option_hash)
-  option_hash[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
+def current_directory_content_names(options)
+  options[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
 def sort_vertically(content_names, options)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -53,7 +53,7 @@ def parse_command_line_option
   opt.on('-a', '--add', 'add an item') { option_lower_a = true }
   opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
   opt.parse(ARGV)
-  { option_lower_a: , option_reverse: }
+  { option_lower_a:, option_reverse: }
 end
 
 options = parse_command_line_option

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -57,15 +57,33 @@ def parse_command_line_option
   { option_lower_a:, option_reverse:, option_lower_l: }
 end
 
+def sort_with_details(content_names); end
+
 options = parse_command_line_option
 
 content_names = current_directory_content_names(options)
-max_content_name_length = content_names.map(&:length).max
 
 simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
-sorted_content_names = sort_vertically(simple_sorted_content_names)
 
-sorted_content_names.each do |sorted_content_name|
-  sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }
-  puts
+if options[:option_lower_l]
+  sorted_content_names_with_details = sort_with_details(simple_sorted_content_names)
+
+  max_content_name_length = Array.new(sorted_content_names_with_details[0].size, 0)
+  sorted_content_names_with_details.each do |sub_array|
+    sub_array.each_with_index do |item, index|
+      max_content_name_length[index] = [max_content_name_length[index], item.length].max
+    end
+  end
+
+  sorted_content_names_with_details.each do |sorted_content_name_with_details|
+    sorted_content_name_with_details.each_with_index { |v, i| print format("%-#{max_content_name_length[i] + 1}s", v) }
+    puts
+  end
+else
+  sorted_content_names = sort_vertically(simple_sorted_content_names)
+  max_content_name_length = content_names.map(&:length).max
+  sorted_content_names.each do |sorted_content_name|
+    sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }
+    puts
+  end
 end

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -47,11 +47,13 @@ end
 
 def parse_command_line_option
   option_lower_a = false
+  option_reverse = false
 
   opt = OptionParser.new
   opt.on('-a', '--add', 'add an item') { option_lower_a = true }
+  opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
   opt.parse(ARGV)
-  { option_lower_a: }
+  { option_lower_a: , option_reverse: }
 end
 
 options = parse_command_line_option

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -10,13 +10,13 @@ def current_directory_content_names(option_hash)
   option_hash[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
-def sort_vertically(content_names)
+def sort_vertically(content_names, options)
   sorted_content_names = []
   max_number_of_lines = (content_names.size / MAX_COLUMN.to_f).ceil
   limit_per_line = (content_names.size / max_number_of_lines.to_f).ceil
   amount_of_max_line_column = limit_per_line - ((max_number_of_lines * limit_per_line) % content_names.size)
 
-  simple_sorted_content_names = content_names.sort
+  simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
   amount_of_max_line_column.times do |line|
     sorted_content_names.push(simple_sorted_content_names[(line * max_number_of_lines), max_number_of_lines])
   end
@@ -60,7 +60,7 @@ options = parse_command_line_option
 
 content_names = current_directory_content_names(options)
 max_content_name_length = content_names.map(&:length).max
-sorted_content_names = sort_vertically(content_names)
+sorted_content_names = sort_vertically(content_names, options)
 
 sorted_content_names.each do |sorted_content_name|
   sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -69,8 +69,8 @@ def sort_with_details(content_names)
       Etc.getpwuid(stat.uid).name,
       Etc.getgrgid(stat.gid).name,
       stat.size.to_s.rjust(5),
-      format('%2d', stat.mtime.strftime('%-m')),
-      format('%2d', stat.mtime.strftime('%-d')),
+      stat.mtime.strftime('%-m').rjust(2),
+      stat.mtime.strftime('%-d').rjust(2),
       stat.mtime.strftime('%R'),
       content_name
     ]
@@ -97,10 +97,16 @@ if options[:option_lower_l]
   sorted_content_names_with_details.each do |sub_array|
     sub_array.each_with_index do |item, index|
       max_content_name_length[index] = [max_content_name_length[index], item.length].max
+    end
+  end
+  
+  sorted_content_names_with_details.each do |sub_array|
+    sub_array.each_with_index do |item, index|
       print format("%-#{max_content_name_length[index] + 1}s", item)
     end
     puts
   end
+
 
 else
   sorted_content_names = sort_vertically(simple_sorted_content_names)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -67,7 +67,7 @@ def sort_with_details(content_names)
       stat.nlink.to_s,
       Etc.getpwuid(stat.uid).name,
       Etc.getgrgid(stat.gid).name,
-      stat.size.to_s.rjust(4),
+      stat.size.to_s.rjust(5),
       format("%2d",stat.mtime.strftime("%-m")),
       format("%2d",stat.mtime.strftime("%-d")),
       stat.mtime.strftime("%R"),

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -48,12 +48,14 @@ end
 def parse_command_line_option
   option_lower_a = false
   option_reverse = false
+  option_lower_l = false
 
   opt = OptionParser.new
   opt.on('-a', '--add', 'add an item') { option_lower_a = true }
   opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
+  opt.on('-l', '', 'show items detail') { option_lower_l = true }
   opt.parse(ARGV)
-  { option_lower_a:, option_reverse: }
+  { option_lower_a:, option_reverse:, option_lower_l: }
 end
 
 options = parse_command_line_option


### PR DESCRIPTION
## 概要
### `ls - r`とは
ファイル表示を降順にするオプション。
※通常時は昇順

### 変更内容
- コマンドラインオプション `-r`を受け取れるようにする
- オプション`-r`が指定された場合、ファイル表示時に降順で表示するようにする。

## Preview
<img width="480" alt="スクリーンショット 2023-09-25 15 27 55" src="https://github.com/daisuke0926dev/ruby-practices/assets/90462400/2a9b27d7-6740-4f7c-a9f4-714bf982b3f2">


## rubocop
<img width="366" alt="スクリーンショット 2023-09-25 15 27 08" src="https://github.com/daisuke0926dev/ruby-practices/assets/90462400/473b151e-3d6b-4ed1-a046-6e4175c3988e">

## Other
前回のpr: https://github.com/daisuke0926dev/ruby-practices/pull/5