### PR TITLE
04 ls -l (詳細な情報と共にリストで表示)を実装

### DIFF
--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -115,8 +115,8 @@ def display_sorted_contents(sorted_content_names_with_details, block_size)
   max_lengths = calculate_max_lengths(sorted_content_names_with_details)
 
   puts("total #{block_size}")
-  sorted_content_names_with_details.each do |sub_array|
-    sub_array.each_with_index do |item, index|
+  sorted_content_names_with_details.each do |items|
+    items.each_with_index do |item, index|
       print format("%-#{max_lengths[index] + 1}s", item)
     end
     puts
@@ -126,8 +126,8 @@ end
 def calculate_max_lengths(sorted_content_names_with_details)
   max_lengths = Array.new(sorted_content_names_with_details[0].size, 0)
 
-  sorted_content_names_with_details.each do |sub_array|
-    sub_array.each_with_index do |item, index|
+  sorted_content_names_with_details.each do |items|
+    items.each_with_index do |item, index|
       max_lengths[index] = [max_lengths[index], item.length].max
     end
   end

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -13,8 +13,7 @@ FILE_TYPE = {
   'file' => '-',
   'link' => 'l',
   'socket' => 's'
-}
-
+}.fleeze
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
 def current_directory_content_names(options)
@@ -95,7 +94,7 @@ def build_detailed_content(file_stat, content_name)
     file_stat.mtime.strftime('%-m').rjust(2),
     file_stat.mtime.strftime('%-d').rjust(2),
     file_stat.mtime.strftime('%R'),
-    file_type(file_stat)=='l' ? "#{content_name} -> #{File.readlink(File.absolute_path(content_name))}" : content_name
+    file_type(file_stat) == 'l' ? "#{content_name} -> #{File.readlink(File.absolute_path(content_name))}" : content_name
   ]
 end
 

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -111,7 +111,8 @@ def translate_permission_number_to_text(permission_number)
   binary_representation.chars.map.with_index { |bit, index| bit.to_i.zero? ? '-' : 'rwx'[index] }.join
 end
 
-def display_sorted_contents(sorted_content_names_with_details, block_size)
+def display_sorted_contents(simple_sorted_content_names)
+  sorted_content_names_with_details, block_size = sort_with_details(simple_sorted_content_names)
   max_lengths = calculate_max_lengths(sorted_content_names_with_details)
 
   puts("total #{block_size}")
@@ -139,8 +140,7 @@ options = parse_command_line_option
 content_names = current_directory_content_names(options)
 simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
 if options[:option_detailed_listing]
-  sorted_content_names_with_details, block_size = sort_with_details(simple_sorted_content_names)
-  display_sorted_contents(sorted_content_names_with_details, block_size)
+  display_sorted_contents(simple_sorted_content_names)
 else
   sorted_content_names = sort_vertically(simple_sorted_content_names)
   max_content_name_length = content_names.map(&:length).max

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -60,9 +60,9 @@ def parse_command_line_option
   option_detailed_listing = false
 
   opt = OptionParser.new
-  opt.on('-a', '--all', 'show all items') { option_show_hidden_files = true }
-  opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
-  opt.on('-l', '', 'detailed list of items') { option_detailed_listing = true }
+  opt.on('-a', '--all', 'do not ignore entries starting with .') { option_show_hidden_files = true }
+  opt.on('-r', '--reverse', 'reverse order while sorting') { option_reverse = true }
+  opt.on('-l', '', 'use a long listing format') { option_detailed_listing = true }
   opt.parse(ARGV)
   { option_show_hidden_files:, option_reverse:, option_detailed_listing: }
 end

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -65,7 +65,7 @@ def sort_with_details(content_names)
   content_names.each_with_index do |content_name, index|
     file_stat = get_file_stat(content_name)
     detailed_contents[index] = build_detailed_content(file_stat, content_name)
-    total_block_size += (file_stat.size / 512).ceil
+    total_block_size += file_stat.blocks
   end
 
   [detailed_contents, total_block_size]

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -10,18 +10,17 @@ def current_directory_content_names(options)
   options[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
-def sort_vertically(content_names, options)
+def sort_vertically(content_names)
   sorted_content_names = []
   max_number_of_lines = (content_names.size / MAX_COLUMN.to_f).ceil
   limit_per_line = (content_names.size / max_number_of_lines.to_f).ceil
   amount_of_max_line_column = limit_per_line - ((max_number_of_lines * limit_per_line) % content_names.size)
 
-  simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
   amount_of_max_line_column.times do |line|
-    sorted_content_names.push(simple_sorted_content_names[(line * max_number_of_lines), max_number_of_lines])
+    sorted_content_names.push(content_names[(line * max_number_of_lines), max_number_of_lines])
   end
 
-  content_names_without_max_line_column = simple_sorted_content_names[amount_of_max_line_column * max_number_of_lines..]
+  content_names_without_max_line_column = content_names[amount_of_max_line_column * max_number_of_lines..]
 
   # 転置後、縦に連番させるために、配列を区切ります
   divided_content_names_without_max_line_column =
@@ -62,7 +61,9 @@ options = parse_command_line_option
 
 content_names = current_directory_content_names(options)
 max_content_name_length = content_names.map(&:length).max
-sorted_content_names = sort_vertically(content_names, options)
+
+simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
+sorted_content_names = sort_vertically(simple_sorted_content_names)
 
 sorted_content_names.each do |sorted_content_name|
   sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -8,7 +8,7 @@ MAX_COLUMN = 3
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
 def current_directory_content_names(options)
-  options[:option_lower_a] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
+  options[:option_show_hidden_files] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
 def sort_vertically(content_names)
@@ -46,16 +46,16 @@ def make_divided_content_names(content_names_without_max_line_column, divid_coun
 end
 
 def parse_command_line_option
-  option_lower_a = false
+  option_show_hidden_files = false
   option_reverse = false
-  option_lower_l = false
+  option_detailed_listing = false
 
   opt = OptionParser.new
-  opt.on('-a', '--add', 'add an item') { option_lower_a = true }
+  opt.on('-a', '--all', 'show all items') { option_show_hidden_files = true }
   opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
-  opt.on('-l', '', 'show items detail') { option_lower_l = true }
+  opt.on('-l', '', 'detailed list of items') { option_detailed_listing = true }
   opt.parse(ARGV)
-  { option_lower_a:, option_reverse:, option_lower_l: }
+  { option_show_hidden_files:, option_reverse:, option_detailed_listing: }
 end
 
 def sort_with_details(content_names)
@@ -127,7 +127,7 @@ end
 options = parse_command_line_option
 content_names = current_directory_content_names(options)
 simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
-if options[:option_lower_l]
+if options[:option_detailed_listing]
   sorted_content_names_with_details, block_size = sort_with_details(simple_sorted_content_names)
   display_sorted_contents(sorted_content_names_with_details, block_size)
 else

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -57,15 +57,33 @@ def parse_command_line_option
   { option_lower_a:, option_reverse:, option_lower_l: }
 end
 
+def sort_with_details(content_names); end
+
 options = parse_command_line_option
 
 content_names = current_directory_content_names(options)
-max_content_name_length = content_names.map(&:length).max
 
 simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
-sorted_content_names = sort_vertically(simple_sorted_content_names)
 
-sorted_content_names.each do |sorted_content_name|
-  sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }
-  puts
+if options[:option_lower_l]
+  sorted_content_names_with_details = sort_with_details(simple_sorted_content_names)
+
+  max_content_name_length = Array.new(sorted_content_names_with_details[0].size, 0)
+  sorted_content_names_with_details.each do |sub_array|
+    sub_array.each_with_index do |item, index|
+      max_content_name_length[index] = [max_content_name_length[index], item.length].max
+    end
+  end
+
+  sorted_content_names_with_details.each do |sorted_content_name_with_details|
+    sorted_content_name_with_details.each_with_index { |v, i| print format("%-#{max_content_name_length[i] + 1}s", v) }
+    puts
+  end
+else
+  sorted_content_names = sort_vertically(simple_sorted_content_names)
+  max_content_name_length = content_names.map(&:length).max
+  sorted_content_names.each do |sorted_content_name|
+    sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }
+    puts
+  end
 end

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -69,8 +69,8 @@ def sort_with_details(content_names)
       Etc.getpwuid(stat.uid).name,
       Etc.getgrgid(stat.gid).name,
       stat.size.to_s.rjust(5),
-      format('%2d', stat.mtime.strftime('%-m')),
-      format('%2d', stat.mtime.strftime('%-d')),
+      stat.mtime.strftime('%-m').rjust(2),
+      stat.mtime.strftime('%-d').rjust(2),
       stat.mtime.strftime('%R'),
       content_name
     ]
@@ -97,10 +97,16 @@ if options[:option_lower_l]
   sorted_content_names_with_details.each do |sub_array|
     sub_array.each_with_index do |item, index|
       max_content_name_length[index] = [max_content_name_length[index], item.length].max
+    end
+  end
+  
+  sorted_content_names_with_details.each do |sub_array|
+    sub_array.each_with_index do |item, index|
       print format("%-#{max_content_name_length[index] + 1}s", item)
     end
     puts
   end
+
 
 else
   sorted_content_names = sort_vertically(simple_sorted_content_names)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -87,7 +87,7 @@ end
 
 def build_detailed_content(file_stat, content_name)
   [
-    file_type_and_permissions(file_stat),
+    file_type(file_stat) + file_permission(file_stat),
     file_stat.nlink.to_s,
     Etc.getpwuid(file_stat.uid).name,
     Etc.getgrgid(file_stat.gid).name,
@@ -95,15 +95,16 @@ def build_detailed_content(file_stat, content_name)
     file_stat.mtime.strftime('%-m').rjust(2),
     file_stat.mtime.strftime('%-d').rjust(2),
     file_stat.mtime.strftime('%R'),
-    content_name
+    file_type(file_stat)=='l' ? "#{content_name} -> #{File.readlink(File.absolute_path(content_name))}" : content_name
   ]
 end
 
-def file_type_and_permissions(file_stat)
-  type = FILE_TYPE[file_stat.ftype]
-  p file_stat.mode.to_s(8)
-  permissions = format('%6d', file_stat.mode.to_s(8))[3, 3].chars.map { |num| translate_permission_number_to_text(num.to_i) }.join
-  type + permissions
+def file_type(file_stat)
+  FILE_TYPE[file_stat.ftype]
+end
+
+def file_permission(file_stat)
+  format('%6d', file_stat.mode.to_s(8))[3, 3].chars.map { |num| translate_permission_number_to_text(num.to_i) }.join
 end
 
 def translate_permission_number_to_text(permission_number)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -20,7 +20,7 @@ def current_directory_content_names(options)
   options[:option_show_hidden_files] ? Dir.foreach('.').to_a : Dir.foreach('.').reject { |content_name| content_name.start_with?('.') }
 end
 
-def sort_vertically(content_names)
+def convert_to_table(content_names)
   sorted_content_names = []
   max_number_of_lines = (content_names.size / MAX_COLUMN.to_f).ceil
   limit_per_line = (content_names.size / max_number_of_lines.to_f).ceil
@@ -142,7 +142,7 @@ simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reve
 if options[:option_detailed_listing]
   display_contents_with_details(simple_sorted_content_names)
 else
-  sorted_content_names = sort_vertically(simple_sorted_content_names)
+  sorted_content_names = convert_to_table(simple_sorted_content_names)
   max_content_name_length = content_names.map(&:length).max
   sorted_content_names.each do |sorted_content_name|
     sorted_content_name.each { |v| print format("%-#{max_content_name_length + 1}s", v) }

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -72,7 +72,7 @@ def sort_with_details(content_names)
   detailed_contents = Array.new(content_names.size)
 
   content_names.each_with_index do |content_name, index|
-    file_stat = get_file_stat(content_name)
+    file_stat = file_stat(content_name)
     detailed_contents[index] = build_detailed_content(file_stat, content_name)
     total_block_size += file_stat.blocks
   end
@@ -80,7 +80,7 @@ def sort_with_details(content_names)
   [detailed_contents, total_block_size]
 end
 
-def get_file_stat(content_name)
+def file_stat(content_name)
   File.lstat(File.join(Dir.pwd, content_name))
 end
 

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -82,7 +82,7 @@ def sort_with_details(content_names)
 end
 
 def get_file_stat(content_name)
-  File.stat(File.join(Dir.pwd, content_name))
+  File.lstat(File.join(Dir.pwd, content_name))
 end
 
 def build_detailed_content(file_stat, content_name)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -67,7 +67,7 @@ def sort_with_details(content_names)
       stat.nlink.to_s,
       Etc.getpwuid(stat.uid).name,
       Etc.getgrgid(stat.gid).name,
-      stat.size.to_s.rjust(4),
+      stat.size.to_s.rjust(5),
       format("%2d",stat.mtime.strftime("%-m")),
       format("%2d",stat.mtime.strftime("%-d")),
       stat.mtime.strftime("%R"),

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -5,6 +5,16 @@ require 'optparse'
 require 'etc'
 
 MAX_COLUMN = 3
+FILE_TYPE = {
+  'fifo' => 'p',
+  'characterSpecial' => 'c',
+  'directory' => 'd',
+  'blockSpecial' => 'b',
+  'file' => '-',
+  'link' => 'l',
+  'socket' => 's'
+}
+
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
 def current_directory_content_names(options)
@@ -90,7 +100,8 @@ def build_detailed_content(file_stat, content_name)
 end
 
 def file_type_and_permissions(file_stat)
-  type = file_stat.ftype[0] == 'd' ? 'd' : '-'
+  type = FILE_TYPE[file_stat.ftype]
+  p file_stat.mode.to_s(8)
   permissions = format('%6d', file_stat.mode.to_s(8))[3, 3].chars.map { |num| translate_permission_number_to_text(num.to_i) }.join
   type + permissions
 end

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -13,7 +13,7 @@ FILE_TYPE = {
   'file' => '-',
   'link' => 'l',
   'socket' => 's'
-}.fleeze
+}.freeze
 
 # ファイル名ディレクトリ名を包括するので、コンテンツと称しています。
 def current_directory_content_names(options)

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -48,12 +48,14 @@ end
 def parse_command_line_option
   option_lower_a = false
   option_reverse = false
+  option_lower_l = false
 
   opt = OptionParser.new
   opt.on('-a', '--add', 'add an item') { option_lower_a = true }
   opt.on('-r', '--reverse', 'show reverse items') { option_reverse = true }
+  opt.on('-l', '', 'show items detail') { option_lower_l = true }
   opt.parse(ARGV)
-  { option_lower_a:, option_reverse: }
+  { option_lower_a:, option_reverse:, option_lower_l: }
 end
 
 options = parse_command_line_option

--- a/04.ls/main.rb
+++ b/04.ls/main.rb
@@ -67,7 +67,7 @@ def parse_command_line_option
   { option_show_hidden_files:, option_reverse:, option_detailed_listing: }
 end
 
-def sort_with_details(content_names)
+def add_file_stats(content_names)
   total_block_size = 0
   detailed_contents = Array.new(content_names.size)
 
@@ -111,8 +111,8 @@ def translate_permission_number_to_text(permission_number)
   binary_representation.chars.map.with_index { |bit, index| bit.to_i.zero? ? '-' : 'rwx'[index] }.join
 end
 
-def display_sorted_contents(simple_sorted_content_names)
-  sorted_content_names_with_details, block_size = sort_with_details(simple_sorted_content_names)
+def display_contents_with_details(simple_sorted_content_names)
+  sorted_content_names_with_details, block_size = add_file_stats(simple_sorted_content_names)
   max_lengths = calculate_max_lengths(sorted_content_names_with_details)
 
   puts("total #{block_size}")
@@ -140,7 +140,7 @@ options = parse_command_line_option
 content_names = current_directory_content_names(options)
 simple_sorted_content_names = options[:option_reverse] ? content_names.sort.reverse : content_names.sort
 if options[:option_detailed_listing]
-  display_sorted_contents(simple_sorted_content_names)
+  display_contents_with_details(simple_sorted_content_names)
 else
   sorted_content_names = sort_vertically(simple_sorted_content_names)
   max_content_name_length = content_names.map(&:length).max


### PR DESCRIPTION
## 概要
### `ls - l`とは
詳細なファイル情報と共に縦一列のリストで表示するオプション

### 変更内容
- コマンドラインオプション `-l`を受け取れるようにする
- オプション`-l`が指定された場合、詳細なファイル情報と共に縦一列のリストで表示するようにする。

### 懸念点
パーミッションを表示している部分で、@(Extended Attributes)マークが表示されている。
一般的なlsコマンドには表示されない項目であると思われるため、未実装。

## Preview
<img width="548" alt="スクリーンショット 2023-09-29 12 44 23" src="https://github.com/daisuke0926dev/ruby-practices/assets/90462400/ca426e7d-298d-4782-9010-7eed1b2396bc">


## rubocop
<img width="349" alt="スクリーンショット 2023-09-29 11 53 15" src="https://github.com/daisuke0926dev/ruby-practices/assets/90462400/7e1b9118-5a0b-4433-a947-2c9b2832697d">


## Other
前回のpr: https://github.com/daisuke0926dev/ruby-practices/pull/6